### PR TITLE
Mitigate CVE-2025-1974

### DIFF
--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -9,6 +9,12 @@ ingress-nginx:
     ingressClassByName: true
     watchIngressWithoutClass: false
 
+    # image:
+    #   tag: "v1.12.1" # depending on https://github.com/kubernetes/ingress-nginx/pull/13068 to be merged
+
+    admissionWebhooks:
+      enabled: false
+
     resources:
       requests:
         cpu: 535m


### PR DESCRIPTION
Mitigation steps taken from [Kubernetes Blog (deploy preview)](https://deploy-preview-50219--kubernetes-io-main-staging.netlify.app/blog/2025/03/24/ingress-nginx-cve-2025-1974/) ([PR: website#50219](https://github.com/kubernetes/website/pull/50219))

Mitigation implemented in ingress-nginx v1.12.1 ([PR: ingress-nginx#13068](https://github.com/kubernetes/ingress-nginx/pull/13068))